### PR TITLE
New version of SVG logo, smaller fixes

### DIFF
--- a/Pi_symbol.svg
+++ b/Pi_symbol.svg
@@ -1,16 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg id="svg139" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" viewBox="-0.244 -0.228 15 12" height="12" width="15" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
- <metadata id="metadata143">
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <defs id="defs19">
-  <path id="E" d="m3.716-5.4h1.62c-0.387 1.607-0.63 2.654-0.63 3.802 0 0.2 0 1.75 0.588 1.75 0.3 0 0.56-0.273 0.56-0.516 0-0.072 0-0.1-0.1-0.316-0.387-1-0.387-2.224-0.387-2.324 0-0.086 0-1.105 0.3-2.396h1.607c0.186 0 0.66 0 0.66-0.46 0-0.316-0.273-0.316-0.53-0.316h-4.72c-0.33 0-0.818 0-1.478 0.703-0.373 0.406-0.832 1.166-0.832 1.253s0.072 0.115 0.158 0.115c0.1 0 0.115-0.043 0.187-0.13 0.744-1.165 1.481-1.165 1.849-1.165h0.818c-0.316 1.067-0.686 2.316-1.851 4.826-0.115 0.23-0.115 0.258-0.115 0.344 0 0.3 0.258 0.373 0.387 0.373 0.416 0 0.53-0.373 0.703-0.976l0.373-1.334 0.832-3.242z"/>
- </defs>
- <use id="use77" xlink:href="#E" transform="matrix(1.8963 0 0 1.8963 -403.66 -118.54)" height="100%" width="100%" y="68.566002" x="212.519" stroke-width=".59589" fill="#7054a4"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="15"
+   height="12"
+   viewBox="-0.244 -0.228 15 12"
+   id="svg139">
+  <metadata
+     id="metadata143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs19">
+    <path
+       d="m3.716-5.4h1.62c-0.387 1.607-0.63 2.654-0.63 3.802 0 0.2 0 1.75 0.588 1.75 0.3 0 0.56-0.273 0.56-0.516 0-0.072 0-0.1-0.1-0.316-0.387-1-0.387-2.224-0.387-2.324 0-0.086 0-1.105 0.3-2.396h1.607c0.186 0 0.66 0 0.66-0.46 0-0.316-0.273-0.316-0.53-0.316h-4.72c-0.33 0-0.818 0-1.478 0.703-0.373 0.406-0.832 1.166-0.832 1.253s0.072 0.115 0.158 0.115c0.1 0 0.115-0.043 0.187-0.13 0.744-1.165 1.481-1.165 1.849-1.165h0.818c-0.316 1.067-0.686 2.316-1.851 4.826-0.115 0.23-0.115 0.258-0.115 0.344 0 0.3 0.258 0.373 0.387 0.373 0.416 0 0.53-0.373 0.703-0.976l0.373-1.334 0.832-3.242z"
+       id="E" />
+  </defs>
+  <use
+     style="fill:#491f7a;fill-opacity:1"
+     fill="#7054a4"
+     stroke-width=".59589"
+     x="212.519"
+     y="68.566002"
+     width="100%"
+     height="100%"
+     transform="matrix(1.8963 0 0 1.8963 -403.66 -118.54)"
+     xlink:href="#E"
+     id="use77" />
 </svg>

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ html, body {
 }
 
 * {
-  font-family: 'Exo 2', sans-serif;
+  font-family: 'Exo 2';
   box-sizing: border-box;
 }
 
@@ -31,7 +31,7 @@ a {
 p {
   text-align: justify;
   text-indent: 0.75em;
-  line-height: 1.4em;
+  line-height: 1.5em;
   margin: 0.2em 0;
 }
 
@@ -251,7 +251,7 @@ footer > span {
 
 @media screen and (max-width: 400px) {
   body, html {
-    font-size: 14px;
+    font-size: 12px;
   }
   
   h1 { font-size: 1.5em; }


### PR DESCRIPTION
The smaller font in resolutions below 400px, paragraph interline little bigger, logo update.